### PR TITLE
add WPT for lang attribute affecting rendering of second text run

### DIFF
--- a/css/css-fonts/lang-attribute-affects-rendering-of-second-text-run-ref.html
+++ b/css/css-fonts/lang-attribute-affects-rendering-of-second-text-run-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    * { font-size: 50px }
+
+    @font-face {
+      font-family: test-font-family;
+      /* <Lato-Medium.ttf> provides different ligatures for English and
+         Turkish. */
+      src: url(support/fonts/Lato-Medium.ttf);
+    }
+
+    div { font-family: test-font-family; }
+  </style>
+</head>
+<body>
+  `lang="en"` should render ligatures, `lang="tr"` not.
+  Different scripts should correspond to different text runs.
+  <div lang="tr">αβ fi</div>
+</body>
+</html>
+

--- a/css/css-fonts/lang-attribute-affects-rendering-of-second-text-run.html
+++ b/css/css-fonts/lang-attribute-affects-rendering-of-second-text-run.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <link rel="help" href="https://html.spec.whatwg.org/#attr-lang">
+  <link rel="mismatch" href="lang-attribute-affects-rendering-of-second-text-run.html">
+  <style>
+    * { font-size: 50px }
+
+    @font-face {
+      font-family: test-font-family;
+      /* <Lato-Medium.ttf> provides different ligatures for English and
+         Turkish. */
+      src: url(support/fonts/Lato-Medium.ttf);
+    }
+
+    div { font-family: test-font-family; }
+  </style>
+</head>
+<body>
+  `lang="en"` should render ligatures, `lang="tr"` not.
+  Different scripts should correspond to different text runs.
+  <div lang="en">αβ fi</div>
+</body>
+</html>


### PR DESCRIPTION
- **layout: Remove wrong optimization when placing table among floats**
- **Add simulcast support for AV1, enabled by default.**
- **Make `WSRunScanner::TextFragmentData::InvisibleTrailingWhiteSpaceRangeRef` treat white-spaces before invisible preformatted linefeed as visible**
- **Implement VP9 simulcast.**
- **In simulcast wpt, mark VP9 support optional.**
- **Fix order check in WPT webrtc/simulcast/setParameters-maxFramerate.https.html.**
- **Language Detector: Reject when called with aborted signal**
- **Fix ListedElement is focusable pre-check for host with delegatesFocus**
- **Update accname/name/comp_labelledby.html with aria-labeledby [sic] tests (#43698)**
- **Add content to <select multiple> appearance test**
- **Clean up old popover hover utils, and de-footgun mouseOverAndRecord**
- **Translator: Implement AITranslatorFactory abort**
- **Allow custom properties in highlight pseudos**
- **IDB WPTs: Extend idbrequest WPTs to run on workers**
- **IDB WPTs: Extend idbcursor advance related tests to workers**
- **[Gap Decorations]: Setup paint for simple gap cases**
- **Fix up incorrect expectations in WPT tests for hyphenate-limit-chars values.**
- **Add a WPT test for interpolation of hyphenate-limit-chars values.**
- **[carousel] Fix layout parent style for carousel pseudos**
- **Use assert_throws_js in content-security-policy/securitypolicyviolation/source-file.html (#50360)**
- **Add more tests for trusted-types-sink violation reports. (#50276)**
- **[functions] Add CSSFunctionRule, and related interfaces**
- **Improve select-mouse-behavior.tentative.html**
- **Remove native-popup-with-wrapper-div.tentative.html**
- **IDB WPTs: Extend idbobjectstore-exception related tests to workers**
- **Match customizable select focus ring to border**
- **Calculate TimeToEffectChange for active reverse animations**
- **temp rollback until the end of Interop 2024 (#50392)**
- **Flag the restriction on adoptedStyleSheets constructed styles**
- **Treat FULLWIDTH TILDE as CJK punctuation for segment break transformation purposes.**
- **WPT for `Clear-Site-Data: "cache"` testing that the cache only gets cleared in the correct storage partitions**
- **Add keyboard-activation for interesttarget elements [10/N]**
- **Need to check style before inert attribute for editability**
- **IDB WPTs: Extend idbtransaction WPTs to run on workers**
- **Change order of [inert] vs :modal UA style for interactivity**
- **WebKit export: [css-images-4] Gradients with only one stop should be supported (#50377)**
- **Add `cssText` test cases in `cssom-pagerule.html` (#50401)**
- **Add `togglescreenshare` and `voiceactivity` test coverage (#50402)**
- **Perform pending operations when the view transition is animating.**
- **[functions] Handle fallbacks for local substitutions**
- **Parse animation-trigger shorthand**
- **Sync interfaces/ with @webref/idl 3.59.2 (#50407)**
- **[carousel] Move ::scroll-marker and ::scroll-marker-group tests to WPT**
- **[wdspec] `browsingContext.navigationCommitted` event (#50413)**
- **[DIP] Plumb DIP reporter in CacheStorage**
- **Provide layer bounds for text-shadow rendering**
- **Avoid starting transitions if values can't be interpolated**
- **Add remaining color spaces for interpolation**
- **Language Detector: Implement signal for AILanguageDetectorFactory.create**
- **FLEDGE: Include BSRID w/creative scanning metadata in TSS request.**
- **Mark select-home-end-pagedown-pageup-detailed.optional.html slow**
- **Remove special boolean handling in ResolveToConfigResolved::React()**
- **IDB WPTs: Extend idbfactory_deleteDatabase WPTs to run on workers.**
- **Don't clear ForceReattachLayoutTree state on <slot> with display lock.**
- **Reland "Ensure AbortSignal.throwIfAborted doesn't modify the message of an abort error"**
- **[wpt] Add support for "userContexts" argument to "script.addPreloadScript" command.**
- **[wdspec] Add tests for "userContexts" argument to "script.addPreloadScript" command.**
- **Forward "MINIDUMP_SAVE_PATH" env variable to Android only if it is present.**
- **Exclude Korean currency symbol (WON SIGN) from being treated like Chinese/Japanese characters during CSS segment break transformation.**
- **Remove tentative from dialog toggle events test (#50428)**
- **[anchor] Handle flipping anchor(inside) and anchor(outside) values.**
- **Add more tests for 'discard' edge cases in SVG animations**
- **Remove invalid assertion from line-breaker hyphenation code.**
- **[css-fonts] font-style: oblique 0deg should serialize as font-style: normal (#50429)**
- **Add three dialog crash tests (#50431)**
- **Consider for ImplicitAnchorElement() for ShouldStoreOldStyle()**
- **IDB WPTs: Extend idbobjectstore related tests to workers**
- **[anchor] Avoid negative IMCB correctly with scroll shift.**
- **[wdspec] fix `browsingContext.navigationCommitted` test (#50419)**
- **Add support for inline if function**
- **Correct TT sink value for SVGScriptElement innerHTML test (#50441)**
- **Use computed value of query specified value in if style conditions**
- **[wdspec] add user context subscription tests (#50434)**
- **Remove incorrect TT subtest for SVGScriptElement text (#50445)**
- **layout: Fix painting order of collapsed table borders**
- **CSSPrimitiveValue::ConvertTo<> can have percentage input**
- **Improve TT tests for SVG and HTML script innerHTML (#50442)**
- **Resolve substitution functions in if() style condition**
- **[Editing] Resolve styles during serialization**
- **Add new request-close command for dialogs**
- **Add fuzzy data to wpt/css/css-pseudo/target-text-shadow-horizontal.html**
- **Revert "WebKit export: [popover] Tabbing out of a popover causes a hang in certain cases (#50235)" (#50462)**
- **Use dedicated params dict for each canvas type in WPT test generator**
- **Delete html/webappapis/scripting/event-loops/fully_active_document.window.js (#50454)**
- **Translator: Align more with explainer**
- **[functions] Implement dynamic scoping**
- **Translator: Mock the monitor option**
- **Revise filtering for Content-Encoding in ResourceTiming**
- **Fix selectURL() loaded iframes not getting window.fence. (#50394)**
- **Move Mutation Events removal subtests into separate test for Interop2025 (#50342)**
- **Inert attribute should not cause html inertness**
- **Revert "Fix old html.css selectors for popover/dialog"**
- **[SRI Message Signatures] Shift SRI to require `unencoded-digest`.**
- **[SRI Message Signatures] Shift to enforce `unencoded-digest`.**
- **interop/vt: Fix duplicate-tag-rejects-start.html syntax errors**
- **Update geometry when pathLength of polygon or polyline changes**
- **part 4: Add a WPT test for <input type="search" role="combobox">.**
- **IDB WPTs: Extend IndexedDB WPTs to run on workers.**
- **[Gap Decorations]: Parse `column-rule-break` property**
- **[SVG] Fix viewport calculation for uninstanced symbol elements.**
- **Store display-name with FileSystemFileHandle to allow mime guess**
- **Ensure that unknown match results don't get overwritten in selector lists.**
- **[remote] Improve window resizing and positioning reliability.**
- **[WebDriver BiDi] Add test for providing both contexts (#50455)**
- **Add .yml config for scroll-state wpt tests**
- **[wdspec] fix the user context field assertion (#50482)**
- **[functions] Detect cycles between local variables**
- **[wdspec] add wait_for_events helper fixture (#50439)**
- **[functions] Substitute var() via attr() locally**
- **Scroll visually to position:fixed element in ScrollFrameIntoView if necessary.**
- **Fix natural size for SVG images**
- **Clean up some stale debug options for ServoDriver**
- **[Sanitizer API] Update default handling for comments and data-*.**
- **Use IDL enums for all CanvasTextDrawingStyles in Canvas2D**
- **Revert "Include <img> alt text in <option> labels"**
- **Improve the stop-cacheability predicate for CSS gradients**
- **[Gap Decorations]: Parse `row-rule-break` property**
- **Lazy-render Jinja parameters in Canvas WPT test generator**
- **Revert "[Editing] Resolve styles during serialization"**
- **Revert "Use IDL enums for all CanvasTextDrawingStyles in Canvas2D"**
- **Round main thread scroll offsets**
- **IDB WPTs: Extend interleaved-cursor WPTs to run on workers**
- **Ensure ::scroll-button disabled state uses correct rounded snapped positions**
- **IDB WPTs: Extend several IDB WPTs to run on workers (Part 5)**
- **IDB WPTs: Extend several IDB WPTs to run on workers (Part 6)**
- **IDB WPTs: Extend several IDB WPTs to run on workers (Part 7)**
- **IDB WPTs: Extend several IDB WPTs to run on workers (Part 8)**
- **Add test for scroll offsets with fractional zoom**
- **Ensure atomic style change events for ElementLayoutUpgrade**
- **Add oncommand Event Handler property to IDL**
- **DOM: Remove impl-specific Observable error assertions**
- **CSS corner-shape initial parsing**
- **[functions] Detect cycles between <dashed-functions>**
- **[rust png] Stall the test HTTP request at a slightly later offset.**
- **Bluetooth: Migrate some WPT tests to use Bidi SimulateAdapter**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=285264 (#50340)**
- **Fix WPTs failing since the switch to headless_shell**
- **[PEPC] Address exploitable border styling**
- **Handle cycle in inline if() function**
- **Sync interfaces/ with @webref/idl 3.59.3 (#50524)**
- **[carousel] Don't create ::scroll-marker without ::scroll-marker-group**
- **Support corner-shape: superellipse(x)**
- **Reland "Use IDL enums for all CanvasTextDrawingStyles in Canvas2D"**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=279569 (#50517)**
- **Ensure ::scroll-button activation accounts for scale factor**
- **Fix an invalidation issue with `:has-interest` [11/N]**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=286920 (#50531)**
- **IDB WPTs: Extend idbobjectstore_opencursor related tests to workers**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=278925 (CSS timing functions should not eagerly evaluate calc()) (#50533)**
- **Don't treat onreadystatechange/onvisibilitychange as HTML content attributes.**
- **Navigation API: window.stop() after-transition traversal should actually block the traversal**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=287082 (#50521)**
- **[reading-flow] Add CSS reading-order as a valid property**
- **[FedCM] Store profile info in Login Status setting**
- **Don't allow nested <select>s**
- **webn:: disable float argmin/max on intel mac**
- **Render muted audio when rendering media streams**
- **Revert "Always slot select options into ::picker(select)"**
- **[Gap Decorations]:  Parse `column-rule-outset` property**
- **Remove the separate 'normal' value of font-style types, as it is a synonym for 'oblique 0deg'; always serialize 'oblique 0deg' as 'normal'.**
- **Revert "Revert "Always slot select options into ::picker(select)""**
- **[carousel] Support :focus-within on ::scroll-marker-group**
- **CSS corner-shape: support the rest of the keywords**
- **Add WPT for container-relative units in ::selection**
- **Add overflow shorthand test for logical longhands**
- **[functions] Support @supports within @function rules**
- **Check lack of semicolon after last skipped declaration value in if()**
- **[functions] Support @media within @function**
- **Merge css-scroll-snap & css-scroll-snap-2 WPTs**
- **patch 1 - Add an oblique-only value to the font-synthesis-style property.**
- **patch 2 - Support the font-synthesis-style:oblique-only value in font selection & rendering.**
- **[css-highlight-api] Check Node::isConnected in ValidateHighlightMarkers**
- **Implement support for referencetarget with interesttarget**
- **[SAA] Add tentative WPTs for stricter Same Origin Policy adherence**
- **Reland "Revert "Always slot select options into ::picker(select)""**
- **Refactor `XRFrameData` to include `XRRenderInfo`**
- **WebKit export: [WebVTT Interop] Test issue: text color is different between actual and expected file (#80ff80 vs #00ff00) (#50581)**
- **WebKit export: Some WebVTT WPT have a border around the video in the ref file but not the actual file (#50582)**
- **[Gap Decorations]:  Parse `row-rule-outset` property**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=287237 (#50559)**
- **Implement support for referencetarget with commandfor**
- **Add WPT tests**
- **Add WPT tests**
- **Fix fixed position descendant**
- **Split up the WPT test**
- **Organize WPT test CSS**
- **Fix WPT css endline**
- **Mark switch-picker-appearance WPT slow**
- **Mark select-home-end-pagedown-pageup WPT slow**
- **Add a WPT test for setTimeout vs setInterval clamping.**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=287239 (#50560)**
- **Fix text direction inherit in workers**
- **Make `Event::GetPrimaryFrameOfEventTarget` return `nullptr` if target is moved outside the original `nsPresContext**
- **Fix whitespace in overflow-shorthand-002.html (#50596)**
- **dom: Always replace unpaired surrogates when handling page text**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=287327 (#50593)**
- **[Editing] Fix content loss during list indent operation**
- **IDB: Make Transaction::abort() throw error when txn is committing**
- **Prevent choosing a font face labelled 'italic' when the style explicitly requested 'oblique'.**
- **Merge Blink's test case for fallback handling of paint servers to WPT (#50603)**
- **Ensure that attr-taint carries through if()**
- **[carousel] Enable cycling for keyboard navigation of ::scroll-marker(s)**
- **Revert "Provide layer bounds for text-shadow rendering"**
- **Revert "Fixed purely physical mapping bug for vertical text and decorations."**
- **Implement NavigateEvent.redirect()**
- **WebKit export: Remove perfectly valid progress() test from invalid examples test (#50615)**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=287415 (#50612)**
- **[wdspec] Extend test suite for "userContexts" argument of "sessions.subscribe" command.**
- **Implement orientation support for WebCodecs VideoDecoder.**
- **[carousel] Focus after activating scroll marker is its scroll target**
- **<style> had no end-tag. (#50197)**
- **Clear-site-data: "cache": Add more tests for iframes within iframes**
- **Update HTTP Accept header when fetching a JSON module.**
- **Part 4: Remove connect-src:'none' restriction from the preload-csp.sub.html.**
- **Parse the corner-shape shorthand**
- **[wdspec] align navigation tests with spec (#50527)**
- **Reflect command attribute to known-valid values**
- **css-function tests for shadow dom (#50631)**
- **implemented feture and tests**
- **Add NS decl in wpt/svg/pservers/reftests/fill-fallback-invalid-uri.svg**
- **Ensure child spans of an empty span receive a zero block start edge.**
- **Expose Captured Surface Resolution while screensharing for Windows**
- **[WebDriver BiDi] Remove obsolete test (#50636)**
- **Fix dialog crashers related to `<dialog open>`**
- **Await Promise so test actually waits for frame to load**
- **Fixed the crash when calling moveBefore on a custom element without implementing disconnectedCallback**
- **[DC] Fix/Improve Digital Credentials permission policy wpt**
- **[flex] Fix justify-content:stretch**
- **Add tests for button type reflection and behaviour with command/commandfor and popovertarget (#50583)**
- **webnn: Support the dequantizeLinear operator in CoreML**
- **Add crashtest.**
- **Fix description for unreachable fullscreenerror event (#50624)**
- **Map container scroll-state query tests to web-features (#50237)**
- **Map speculation rules tests to web-features (#50245)**
- **Add descriptions to fullscreen asserts (#50625)**
- **Remove broken NoCorsSubresourceCookiesFromFrame helper (#50613)**
- **WPT for the sandbox `allow-same-site-none-cookies` value**
- **[carousel] Handle out-of-flow positioned scrollers.**
- **wasm: Remove 'tentative' from JS-SB tests and don't test shadowrealm.**
- **Suppress webdriver executor timeout when debugger present.**
- **Fix a DCHECK when a block is started in the @property prelude.**
- **Test `overflow-clip-margin` with `border-radius`**
- **Resolve CSS keywords in if() condition**
- **Add requestClose() subtests for initially open dialog (#50432)**
- **script: fix spurious animation checks to correctly invoke rAF callbacks**
- **UTF-8 charset for overflow-clip-margin-border-radius.html**
- **Don't render whitespace option label attributes**
- **Add external css to canvas grid tests**
- **[Grid] Fix syntax error in grid-automatic-minimum-for-auto-rows-001**
- **IDB WPTs: Extend idbdatabase related tests to workers**
- **Update on-device Web Speech APIs**
- **IDB WPTs: Extend idbcursor related tests to workers**
- **IDB WPTs: Extend idbcursor-continue related tests to workers**
- **[reading-flow] Implement reading-order sorting**
- **Support concurrent speech recognition sessions**
- **Cancels prerenders when browsing data removal is run.**
- **Revise the AudioWorkletProcessor.process() retrieval during rendering.**
- **Remove focus fixup for removal of `<dialog open>` attribute**
- **Align pixels through render surfaces when possible**
- **Update private aggregation web tests to use test public key**
- **Deflake (properly) canvas direction tests**
- **Sync interfaces/ with @webref/idl 3.59.4 (#50677)**
- **Add wpt test for inline if() invalivation**
- **Add daily WPE WebKit runs to the CI (Taskcluster).**
- **require-sri-for: 'script'**
- **Update collapsible placeholder computation**
- **[Sanitizer] Properly recurse into <template> contents.**
- **Fix Incorrect "extension" of CSS gradient with "longer hue" interpolation into regions beyond the first/last color stop**
- **LoAF: Add sourceLine and sourceColumn to PerformanceScriptTiming**
- **Add AnimationTrigger IDL**
- **[functions] Support @container within @function**
- **Enable InputClosesSelect by default**
- **Fix interactive elements in customizable select picker**
- **Add test for xml regression fix**
- **Add a test for ua keyframe lookups.**
- **serial: Increase timeout for loopback manual WPT.**
- **[HighlightsFromPoint] Add WPT tests**
- **Add src attribute to potential Permissions Policy report**
- **[Blob URL] Flakey cross-partition-navigation.https.html WPT Fix**
- **[Editing] Remove newline while copy pasting text around a button containing empty text.**
- **Reland "[Editing] Resolve styles during serialization"**
- **Ensure that attr-taint carries through if() condition**
- **float16 canvas: Add WPT tests for round-trip precision**
- **[wdspec] Enhance user prompt tests for an optional data property.**
- **WPT tests: Remove use of never-shipped APIs**
- **Improve require-sri-for test coverage**
- **[Signature-based SRI] Support `ed25519-...` assertions in CSP.**
- **Don't escape UA shadow trees during selector checking**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=287694 (#50708)**
- **Add manual WPT for triple-key partitioning of :visited links**
- **WebKit export: [popover] Tabbing out of a popover causes a hang in certain cases (#50463)**
- **Make generated canvas test parameters importable as Jinja templates**
- **::scroll-marker activation only scrolls associated scroller.**
- **DOM: Implement ref-counted Observable producer**
- **Add customizable select top layer animation regression tests**
- **Simplify _write_cairo_images to only write a single file**
- **Translator: Consume user activation when availability is "after-download"**
- **Add Trusted Type test to set attributes by different means.**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=287704 (#50718)**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=287705 (#50719)**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=286723 (#50736)**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=286781 (#50737)**
- **Fix <select> GetListItems crash**
- **Add a parameter to control whether canvas test variants are enabled**
- **WebKit export from bug: [scroll-animations] WPT test scroll-animations/css/view-timeline-with-transform-on-subject.html is a failure (#50739)**
- **WebKit export: Update `contrast-color()` for removal of `max` parameter**
- **add DataTransferItemList remove() test case**
- **Handle the case when a gradient only have a single stop which contains missing components**
- **[Editing] Include open shadow roots in RangeLength for MoveParagraphs.**
- **[Signature-based SRI] Typo in test description.**
- **Try to de-flake registered-neutral-keyframe.html**
- **Fix the reference link for canvas turbulence test**
- **[css-ui] appearance: Also generate grouped tests for kind-of-widget-fallback**
- **[webrtc-encoded-transform] Add support for metadata timestamps.**
- **Respect FunctionContext when substituting if()**
- **[wdspec] Tests for the installing and uninstalling webExtensions .**
- **Fix lint errors**
- **[cssom] Reattach wrappers during CSSStyleRule::setSelectorText**
- **[Sanitizer] Implement new defaults API.**
- **Resolve css scale interpolation number before interpolation**
- **Add tests for sizing keywords on flex items**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=285560 (#50755)**
- **[css-mixins] Remove ShadowDOM tests from dashed-function-eval.html**
- **webrtc wpt: add tests for bundlePolicy**
- **Convert web-platform-tests-privatebrowsing from a WPT subsuite to a WPT variant (re-enable web platform tests for service-workers/cache-storage)**
- **Call UnregisterHandler earlier for the old handler**
- **[wdspec] Add tests for fractional x and y values for pointer move action (mouse, touch).**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=287806 (#50756)**
- **[css-ui] Fix help links in generated appearance tests**
- **Create META.yml for css-view-transitions (#50767)**
- **Disallow prefixed properties in highlight pseudos**
- **[SAA] Fix beyond-cookies test**
- **[functions] Validate dashed-functions parse-time**
- **Rendering of corner-shape: bevel**
- **Fix ContainStyleScope::GetPrecedingElementInGenConList.**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=287158 (#50532)**
- **Don't invalidate for nth-of without style data.**
- **Update parsing of *progress() functions notation**
- **Support light-dark() in Highlight Pseudos**
- **[functions] Handle {}-wrapper at parse-time**
- **Translator: Echo empty string**
- **Update Web Speech API to check for detached context**
- **[Signature-based SRI] Simplify path-based tests.**
- **Part 2: Add sub test name in import-style-blocked-sub.html.**
- **Part 3: Update cors-crossorigin-requests.html expected error message.**
- **Bail out from ScrollFrameIntoVisualViewport if the given position:fixed element is outside of the viewport.**
- **Skip view transitions when we resize the viewport size.**
- **Consider the 'preserveAspectRatio' attribute on <feImage>**
- **[functions] Handle {}-wrappers during substitution**
- **Simplify corner-shape inset formula**
- **[CSS][SVG] Fix inheritance for all :visited styles**
- **[testdriver] Add some test_driver.bidi.bluetooth commands and event (#50518)**
- **Mark invokers tests as non-tentative (#42664)**
- **corner-shape: support overflow clipping**
- **Fix carry-forward of missing components for color mixing**
- **Sync interfaces/ with @webref/idl 3.60.0 (#50799)**
- **[Fontations] Prepare some compositing/transform tests for Fontations**
- **Fix timeout of customizable select anchor positioning tests**
- **Improve testing dialog closedby and requestClose**
- **IDB WPTs: Extend three IDB WPTs to run on workers.**
- **WebSpeech: start() throws if detached iframe**
- **Remove the 'variants' param from instantiated variants**
- **vt: Update the blurry text workaround to use render surface snapping**
- **Add testcases for color-mix() hue interpolation where one side is achromatic.**
- **Handle the open dialogs list and close watcher when removed**
- **Fix paint invalidation for ::selection style changes**
- **Fix root-element-background-image-transparency expectations**
- **Add feature flag WebSpeechRecognitionContext to chrome.py (#50703)**
- **IDB WPTs: Extend IDB WPTs to run on workers.**
- **Migrate all 2d.composite meta test to the new canvas test generator**
- **Navigation API: test that soft reloads don't fire a popstate event (#50793)**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=287950 (#50798)**
- **Remove third parameters passed to `TrustedTypePolicyFactory.createPolicy()` (#50821)**
- **[SVG] Add support for SVGAElement's rel / relList attributes**
- **[wdspec] extend `bluetooth.simulatePreconnectedPeripheral` test (#50796)**
- **Add gradient testcase based on the example here.**
- **[Signature-based SRI] Test CORS integration.**
- **Sync interfaces/ with @webref/idl 3.60.0 (#50826)**
- **CSS corner-shape: render "straight" corners as degenerate**
- **[prerender] defer write operations to shared storage on prerendering documents**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=287790 (#50750)**
- **Add a web-platform-tests testing variant for incremental origin initialization**
- **Update old canvas test generator to not add empty notes**
- **corner-shape: render notch**
- **Migrate 2d.fillStyle.parse meta tests to the new test generator**
- **[Permissions] Fix tests (#50779)**
- **Very small cleanup**
- **Remove the old canvas test generator**
- **[wasm][jspi] Fix wpt and reenable WPT tests for JSPI**
- **Fix strong, b default style to be font-weight: bolder**
- **Configure docker image to autospawn pulseaudio on demand (#48878)**
- **Enable wpt/largest-contentful-paint/observe-css-generated-image.html.**
- **Honor snap alignment of scroll-markers**
- **Support parameter descriptor range check in WorkletProcessor.**
- **Fix next selection of radio buttons when outside form**
- **Honor scroll-behavior of scroll-marker-group**
- **Add WPT for stateless bounce track mitigations**
- **Rename html/canvas/tools/yaml-new to html/canvas/tools/yaml**
- **Update four-colors-flip.avif (#50792)**
- **Make gentestutilsunion.py directly runnable**
- **Convert css/filter-effects/filter-subregion-01.html to a real ref test**
- **Fix a crash induced by DocumentPartRoot::clone() of a detached doc**
- **Rename gentestutilsunion.py to gentest.py**
- **Revert "Move Chromium implementation specific WPT."**
- **DOM: test attribute's node document**
- **Improve <select> GetListItems descendant tracking**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=287789 (#50838)**
- **Fix sends-report-on-subdomain-dns-failure.https.html NEL test to use no-path-and-query URL**
- **NEL: Do not submit method and status code if phase is dns**
- **Export WebKit's tests for revamped scoped custom element registry**
- **Rebase and squash**
- **GetSourceImageForCanvas: Use kDoNotChangeAlpha in BaseRenderingContext2D**
- **Abstract away the types of reftest templates in canvas test generator**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=284545 (#50858)**
- **[Sanitizer] Fix typo in test name.**
- **[Sanitizer API] Support removing of javascript: URLs.**
- **Add an img_reference reftest type in canvas WPT test generator**
- **Fix #50744 - Add rules for reformatting html before comparing (#50746)**
- **Map CSS module tests to web-features (#50825)**
- **Field trial testing config for fDO sampling on cookie setting.**
- **Implement the Canvas TextStyles lang attribute**
- **if() boolean-expr of style() and media() queries parsing support**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=285883 (#50874)**
- **Make name: and code: required parameters in the canvas test generator**
- **Support evaluation of <boolean-expr[ style( <style-query> ) ]> queries**
- **[gap-decorations] Parse `row-rule-style` property**
- **Fix a crash in AILanguageDetectorFactory::capabilities() called on a detached frame**
- **Fix scroll-offsets-fractional-zoom.html.**
- **Add CSS Color 4 gradient options to CanvasGradient**
- **Add larger outline for elements with `interesttarget`**
- **DOM: Implement `finally()` Observable operator**
- **Handle overlay scrollbars gracefully in auto-scrollbars.html**
- **Add SpeechRecognition-basics.https.html to chrome.filter**
- **Per https://github.com/w3c/csswg-drafts/issues/9847, empty variables serialize as a single space. (#50890)**
- **webnn: implement quantizeLinear on coreml**
- **DOM: rename importNode()'s deep to selfOnly (and invert its value)**
- **Consolidate reference_file and is_test_reference into a single param**
- **Sync interfaces/ with @webref/idl 3.60.1 (#50894)**
- **Add disconnected tests for command events**
- **Make the dragging interaction still happens when the event target frame is moved/destroyed upon mousedown**
- **Fix canvas turbulence test again**
- **Bump pygithub from 2.5.0 to 2.6.1 in /tools**
- **[functions] Parameters with defaults need not be trailing (WPT)**
- **[carousel] Fix AttachLayoutTree for ::scroll-marker expecting parent**
- **[functions] Ensure that referenced var in outer scope is applied**
- **[functions] Let parameter defaults reference other parameters**
- **layout: Ignore indefinite `stretch` on min and max sizing properties**
- **Add WPT for getInterestGroupAdAuctionData with no sellers**
- **Fix invalid indentation in exception error message**
- **Add behavior test**
- **Update the Sanitizer WebIDL.**
- **Part 1: Defer calling PersistNotification until alertshow**
- **Rename the tests in webrtc/legacy to have optional flags**
- **Export (mostly anchor positioning related) tests from WebKit**
- **Update select-value WPT for SelectParserRelaxation**
- **Document all parameters used by the canvas WPT test generator**
- **[Blob URL] Add more delay to second iframe in subframe partitioning test**
- **Prevent customizable select :focus-visible with mouse**
- **Remove stale TODO about isolation nodes and fragmentation.**
- **[anchor] Anchor recalculation point when switching fallbacks.**
- **Prevent reserved parameters to be used by canvas test definition**
- **LoAF: Set source line and column for promise-resolver**
- **WebNN: Don't run per-op WPTs in non-window contexts**
- **Bump docker/build-push-action from 6.13.0 to 6.14.0 (#50918)**
- **Allow multi-files variants to have no parameters in canvas WPT generator**
- **DOM/HTML: add coverage for shadowRootCustomElements**
- **Fix horizontal/vertical typo for scrollable state**
- **[WPT] Fix WPTs failing on chrome**
- **[Editing] Fix null check for block_flow while creating inline contents on extending selection backward.**
- **[functions] Support IACVT-capture for function arguments**
- **webrtc wpt: add test asserting the order of track events matches the SDP**
- **Regenerate color-type tests that were placed in an extra subdirectory**
- **Expose pixelRatio in the idl behind runtime flag for Windows**
- **[functions] Implement tree-scoped lookups**
- **scroll anchor: Use priority candidate as root for selection**
- **DOM: createElement and createElementNS with scoped registries**
- **Fix OptionList OwnerSelectElement crash**
- **support oncommand content attribute**
- **document-exit-fullscreen-nested-in-iframe.html should not timeout (#50895)**
- **Fix option-label-whitespace.html for firefox**
- **DOM: Add slotchange test for moveBefore()**
- **Allow text-shadow in Custom Highlights**
- **bluetooth: Migrate some WPT tests to use bidi commands**
- **Fix ResolveStopColorWithMissingParams logic**
- **[gap-decorations] Parse `gap-rule-paint-order` property**
- **[Unencoded-Digest] Drop support for SHA-384.**
- **don't assert if the repeat duration is indefinite if we're trying to sample a fill in an active state**
- **Handle 'transparent' when interpolating midpoint hints in the gradient color line.**
- **Paper over node comparison mid unbind.**
- **[SRI Message Signatures] Support the `@status` derived component.**
- **Adjust Fuzzy Matching for backdrop-filter Test to Reduce Rendering Variability (#50951)**
- **Part 1: Input element should always have activation behavior**
- **Part 2: Input element should always defer the form submission during click event**
- **Clear measure cache when rebuilding fragment tree spine.**
- **Rename getActiveServiceWorker to prepare**
- **Set MediaTrackCapabilities max width|height to physical pixel size**
- **corner-shape: support hit-testing**
- **Items that start with a zero width space may be impacted by whitespace collapsing**
- **Command updates (#50829)**
- **Remove FragmentData::FragmentID().**
- **Evaluate media() queries in if() condition**
- **[functions] Use correct TreeScope for @container lookup**
- **Construct ViewTransition object for element.**
- **layout: Support `stretch` cross size for automatic min size in flexbox**
- **Implement ctx.strokeTextCluster()**
- **Cleanup Canvas text direction tests**
- **layout: Support `stretch` cross size for flex base size**
- **cv/carousel: Always style c-v auto locks under scroll-marker-group**
- **[SAA] Remove permission state manipulation from autogrant WPTs**
- **Add UA ::scroll-marker style styling as links**
- **[SRI Message Signatures] Support the `@query` derived component.**
- **[functions] Use keyframe's tree scope when resolving keyframe values**
- **[memory] Fix `InlineItem::index_` for `::first-line`**
- **Fix my name and email in author metadata**
- **webnn: implement prelu on coreml**
- **[IndexedDB] Add more detached array buffer WPT coverage for keys**
- **The container node of the dialog element should be connected to a document**
- **[SRI Message Signatures] `@status` should pull from the response.**
- **[ReferenceTarget] Add tests for implicit label association**
- **[PEPC] Fix display of PEPC in quirks mode when height: auto is used**
- **corner-shape: render all curved superellipse values**
- **CookieStore must enforce the maximum name/value pair size correctly**
- **[wdspec] Move navigation tests for beforeunload in the separate file and fix the test for "browsingContext.navigationStarted" event for beforeunload.**
- **Make WPTs never assume Gecko's tricky trailing white-spaces**
- **[webrtc-encoded-transform] Add support for video metadata timestamps**
- **layout: Use definite cross size to compute flex base size**
- **Evaluate supports() queries inside if() condition**
- **[wdspec] rename addon to extension (#50991)**
- **[testharness.js] Fix issue caused when path contains full stop characters (.)**
- **Squash and don't explicitly use noto-cjk in tests**
- **FLEDGE: Provide browserSignals.utf8{Encode,Decode} to worklets**
- **Support appearance property on ::scroll-button**
- **[gap-decorations] Parse `row-rule-width` property**
- **Update accname/name/comp_host_language_label.html with interior white space tests (#50637)**
- **[carousel] Fix :focus-visible for ::scroll-marker**
- **Set LimitLayerMergeDistance:limit/16 by default**
- **[SAA] Fix sandboxed iframe WPT test timeouts**
- **Navigation API: match the spec on popstate firing behavior**
- **[anchor] Prevent inlines with interesttarget from being culled.**
- **[wdspec] fix test_params_extension_data_path_invalid_webextension (#51005)**
- **webrtc wpt: assert that RTCIceTransport does not show remote candidates**
- **Bail out from CallbackPromiseAdapter::OnErrorAdapter::OnError if context is not valid**
- **Fix missing invalidation of :open pseudo for dialogs**
- **Hide selection changes from web apps which are caused by the hacks of `HTMLEditor**
- **Do not clobber restoring the scroll position on re-snap.**
- **Ensure element's namespace is HTML, SVG or MathML before TT check for event handler attribute.**
- **Update synchronous-callback-skipped-before-run.html to handle the DOM exception.**
- **[ReferenceTarget] Add tests for .labels and invalid ID**
- **[SAA] Remove unnecessary recursive WPT embedding; ignore irrelevant events**
- **Add a test for scoped custom element registry API changes to unbreak Polymer's polyfill**
- **Revert "[webrtc-encoded-transform] Add support for video metadata timestamps"**
- **Configure Chrome for testing extensions (#50993)**
- **Mark SVG element references as tree-scope dependent**
- **Align bluetooth tests with the spec (#51018)**
- **[text-box-trim] Handle new-BFC children correctly.**
- **[text-box-trim] Trim leading / trailing column spanners.**
- **[wdspec] empty extension id should return no web extension error (#51026)**
- **DOM: Fix 'ref-counted producer' Subscriber crash**
- **Translator: Remove deprecated window.translation**
- **Scheduling APIs: associate inherited signals with a SecutityOrigin**
- **Write a README.md documenting the WPT canvas test generator**
- **Fix mistakes in Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-non-TT-realm.html.**
- **Add first set of DBSC web platform tests**
- **[carousel] Use block axis as primary scroll-marker selection axis**
- **NameFrom: Heading... WG preferred DFS over IDS/IDDFS search (#50507)**
- **Add WPTs to check the editing behavior when `contenteditable="plaintext-only"` and `contenteditable="true"` are nested**
- **Improve featureless host matching.**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=284542 (#51030)**
- **Add test case for ElementInternals validation customError (#51039)**
- **[wdspec] fix extension tests for Chrome (#51016)**
- **Add tests of handling collapsed white-space in the result of `.innerText**
- **Reland "[webrtc-encoded-transform] Add support for video metadata timestamps"**
- **Add invalidation tests for sibling-count()/sibling-index()**
- **Make sibling-index()/sibling-count() use flat tree**
- **Correct test for sibling-index() on pseudo element**
- **Sync interfaces/ with @webref/idl 3.60.2 (#51045)**
- **[functions] Respect @layer**
- **cv/carousel: Avoid recursing into non-auto content-visibility subtrees.**
- **Remove auto-revoke for MediaSource BlobURLs**
- **WebKit export of https://bugs.webkit.org/show_bug.cgi?id=288967 (#51057)**
- **Make the condition for "stop decoration propagation" tighter**
- **Add additional DBSC web platform tests**
- **Reland "Always slot select options into ::picker(select)"**
- **vt: Remove layered capture**
- **Allow DBSC credentials to have empty cookie attributes field**
- **Fix flaky WPT**
- **Full implementation of scale transform render surface trigger**
- **Revert "Set LimitLayerMergeDistance:limit/16 by default"**
- **[css-tables] Trigger fixed table layout when not auto.**
- **Fix bug where cc clip paths affected intersection behavior**
- **ComputeBackgroundIsKnownToBeObscured false for block fragmentation.**
- **[wptrunner] Pass Chrome-specific `quitGracefully` when debugging**
- **[wptrunner] Dedup arg-copying loop**
- **[wptrunner] Clean up dead `debug_args()` code for Chrome**
- **[WPT] Fix WPTs failing on chrome due to absence of click event.**
- **[EditContext] Update execution context of EditContext**
- **[SVG] Enhance `getBoundingClientRect` API to return empty size for hidden layout containers.**
- **Update canvas language tests**
- **Add a WPT reftest for intrinsic sizing with an orthogonal child that has borders.**
- **Implement AudioWorklet.port**
- **Add PServiceWorkerRegistration::GetNotifications**
- **Part 6: Fix bug in wpt test**
- **Add WPT checking the `lang` attribute affects the rendering of the second text run**
